### PR TITLE
add `crystal-lang/json_mapping.cr`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,3 +13,5 @@ license: MIT
 dependencies:
   ydl_binaries:
     github: cooperhammond/ydl-binaries
+  json_mapping:
+    github: crystal-lang/json_mapping.cr


### PR DESCRIPTION
this shouldn't be done, I know.
asap, `src/glue/mapper.cr` should be rewritten with `JSON::Serializable`