### PR TITLE
fix #72: Find the JSON data inside the line and trim the rest

### DIFF
--- a/src/search/youtube.cr
+++ b/src/search/youtube.cr
@@ -200,7 +200,15 @@ module Youtube
       # timestamp 11/8/2020:
       # youtube's html page has a line previous to this literally with 'scraper_data_begin' as a comment
       if line.includes?("var ytInitialData")
-        yt_initial_data = JSON.parse(line.split(" = ")[1].delete(';'))
+        # Extract JSON data from line
+        data = line.split(" = ")[2].delete(';')
+        dataEnd = (data.index("</script>") || 0) - 1
+
+        begin
+          yt_initial_data = JSON.parse(data[0..dataEnd])
+        rescue
+          break
+        end
       end
     end
 


### PR DESCRIPTION
The line containing the JSON data doesn't end with it so it has to be trimmed. My fix searches for the closing `</script>` tag marking the end of the data and parsing the substring to JSON instead. I also added a rescue statement so users don't see a crazy error message when something with that changes but instead they see the friendlier `submit a bug` message.

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>