### PR TITLE
make the way mp3s are saved configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If you're one of those cool people who compiles from source
     ```yaml
     binary_directory: ~/.irs/bin
     music_directory: ~/Music
+    filename_pattern: "{track_number} - {title}"
+    directory_pattern: "{artist}/{album}"
     client_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     single_folder_playlist:
@@ -122,6 +124,8 @@ Here's what they do:
 ```yaml
 binary_directory: ~/.irs/bin
 music_directory: ~/Music
+filename_pattern: "{track_number} - {title}"
+directory_pattern: "{artist}/{album}"
 client_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 single_folder_playlist:
@@ -132,8 +136,8 @@ single_folder_playlist:
  - `binary_directory`: a path specifying where the downloaded binaries should
     be placed
  - `music_directory`: a path specifying where downloaded mp3s should be placed.
-    Note that there will be more structure created inside that folder, usually
-    in the format of `music-dir>artist-name>album-name>track`
+ - `filename_pattern`: a pattern for the output filename of the mp3
+ - `directory_pattern`: a pattern for the folder structure your mp3s are saved in
  - `client_key`: a client key from your spotify API application
  - `client_secret`: a client secret key from your spotify API application
  - `single_folder_playlist/enabled`: if set to true, all mp3s from a downloaded
@@ -144,6 +148,55 @@ single_folder_playlist:
  - `single_folder_playlist/unify_into_album`: if set to true, will overwrite
     the album name and album image of the mp3 with the title of your playlist
     and the image for your playlist respectively
+
+
+In a pattern following keywords will be replaced:
+
+| Keyword | Replacement | Example |
+| :----: | :----: | :----: |
+| `{artist}` | Artist Name | Queen |
+| `{title}` | Track Title | Bohemian Rhapsody |
+| `{album}` | Album Name | Stone Cold Classics |
+| `{track_number}` | Track Number | 9 |
+| `{total_tracks}` | Total Tracks in Album | 14 |
+| `{disc_number}` | Disc Number | 1 |
+| `{day}` | Release Day | 01 |
+| `{month}` | Release Month | 01 |
+| `{year}` | Release Year | 2006 |
+| `{id}` | Spotify ID | 6l8GvAyoUZwWDgF1e4822w |
+
+Beware OS-restrictions when naming your mp3s.
+
+Pattern Examples:
+```yaml
+music_directory: ~/Music
+filename_pattern: "{track_number} - {title}"
+directory_pattern: "{artist}/{album}"
+```
+Outputs: `~/Music/Queen/Stone Cold Classics/9 - Bohemian Rhapsody.mp3`
+<br><br>
+```yaml
+music_directory: ~/Music
+filename_pattern: "{artist} - {title}"
+directory_pattern: ""
+```
+Outputs: `~/Music/Queen - Bohemian Rhapsody.mp3`
+<br><br>
+```yaml
+music_directory: ~/Music
+filename_pattern: "{track_number} of {total_tracks} - {title}"
+directory_pattern: "{year}/{artist}/{album}"
+```
+Outputs: `~/Music/2006/Queen/Stone Cold Classics/9 of 14 - Bohemian Rhapsody.mp3`
+<br><br>
+```yaml
+music_directory: ~/Music
+filename_pattern: "{track_number}. {title}"
+directory_pattern: "irs/{artist} - {album}"
+```
+Outputs: `~/Music/irs/Queen - Stone Cold Classics/9. Bohemian Rhapsody.mp3`
+<br>
+
 
 ## How it works
 

--- a/src/bottle/cli.cr
+++ b/src/bottle/cli.cr
@@ -83,7 +83,7 @@ class CLI
       s = Song.new(@args["song"], @args["artist"])
       s.provide_client_keys(Config.client_key, Config.client_secret)
       s.grab_it(@args["url"]?)
-      s.organize_it(Config.music_directory)
+      s.organize_it()
     elsif @args["album"]? && @args["artist"]?
       a = Album.new(@args["album"], @args["artist"])
       a.provide_client_keys(Config.client_key, Config.client_secret)

--- a/src/bottle/config.cr
+++ b/src/bottle/config.cr
@@ -9,6 +9,8 @@ EXAMPLE_CONFIG = <<-EOP
 #{Style.dim "===="}
 #{Style.blue "binary_directory"}: #{Style.green "~/.irs/bin"}
 #{Style.blue "music_directory"}: #{Style.green "~/Music"}
+#{Style.blue "filename_pattern"}: #{Style.green "\"{track_number} - {title}\""}
+#{Style.blue "directory_pattern"}: #{Style.green "\"{artist}/{album}\""}
 #{Style.blue "client_key"}: #{Style.green "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}
 #{Style.blue "client_secret"}: #{Style.green "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}
 #{Style.blue "single_folder_playlist"}: 
@@ -24,6 +26,8 @@ module Config
   @@arguments = [
     "binary_directory",
     "music_directory",
+    "filename_pattern",
+    "directory_pattern",
     "client_key",
     "client_secret",
     "single_folder_playlist: enabled",
@@ -49,6 +53,14 @@ module Config
   def music_directory : String
     path = @@conf["music_directory"].to_s
     return Path[path].expand(home: true).to_s
+  end
+  
+  def filename_pattern : String
+    return @@conf["filename_pattern"].to_s
+  end
+  
+  def directory_pattern : String
+    return @@conf["directory_pattern"].to_s
   end
 
   def client_key : String

--- a/src/bottle/pattern.cr
+++ b/src/bottle/pattern.cr
@@ -1,0 +1,28 @@
+module Pattern
+  extend self
+
+  def parse(formatString : String, metadata : JSON::Any)
+    formatted : String = formatString
+
+    date : Array(String) = (metadata["album"]? || JSON.parse("{}"))["release_date"]?.to_s.split('-')
+
+    keys : Hash(String, String) = {
+      "artist" => ((metadata.dig?("artists") || JSON.parse("{}"))[0]? || JSON.parse("{}"))["name"]?.to_s,
+      "title" => metadata["name"]?.to_s,
+      "album" => (metadata["album"]? || JSON.parse("{}"))["name"]?.to_s,
+      "track_number" => metadata["track_number"]?.to_s,
+      "disc_number" => metadata["disc_number"]?.to_s,
+      "total_tracks" => (metadata["album"]? || JSON.parse("{}"))["total_tracks"]?.to_s,
+      "year" => date[0]?.to_s,
+      "month" => date[1]?.to_s,
+      "day" => date[2]?.to_s,
+      "id" => metadata["id"]?.to_s
+    }
+
+    keys.each do |pair|
+      formatted = formatted.gsub("{#{pair[0]}}", pair[1] || "")
+    end
+
+    return formatted
+  end
+end

--- a/src/glue/album.cr
+++ b/src/glue/album.cr
@@ -42,6 +42,6 @@ class Album < SpotifyList
   end
 
   private def organize(song : Song)
-    song.organize_it(@home_music_directory)
+    song.organize_it()
   end
 end

--- a/src/glue/playlist.cr
+++ b/src/glue/playlist.cr
@@ -69,7 +69,7 @@ class Playlist < SpotifyList
       safe_filename = song.filename.gsub(/[\/]/, "").gsub("  ", " ")
       File.rename("./" + song.filename, (path / safe_filename).to_s)
     else
-      song.organize_it(@home_music_directory)
+      song.organize_it()
     end
   end
 end


### PR DESCRIPTION
This PR adds two new config entrys:
 - `filename_pattern`
 - `directory_pattern`

Internally, the string given by these options is formatted and then used to save the file.
There are no special checks going on, so it stops working if for example `/` appears in the filename_pattern, as a filename can't have `/` in it.
Each new directory in `directory_pattern` has to be separated by a `/`.
If the metadata doesn't contain the entry needed to fill the information, an empty string is inserted.
If `single_folder_playlist` is enabled, `directory_pattern` is ignored and the mp3s are saved in a directory named after the playlist.

Keywords inside the string are replaced with metadata:
| Keyword | Replacement | Example |
| :----: | :----: | :----: |
| `{artist}` | Artist Name | Queen |
| `{title}` | Track Title | Bohemian Rhapsody |
| `{album}` | Album Name | Stone Cold Classics |
| `{track_number}` | Track Number | 9 |
| `{total_tracks}` | Total Tracks in Album | 14 |
| `{disc_number}` | Disc Number | 1 |
| `{day}` | Release Day | 01 |
| `{month}` | Release Month | 01 |
| `{year}` | Release Year | 2006 |
| `{id}` | Spotify ID | 6l8GvAyoUZwWDgF1e4822w |

To get the original conventions the config would have to look like this:
```yaml
binary_directory: ~/.irs/bin
music_directory: ~/Music
filename_pattern: "{track_number} - {title}"
directory_pattern: "{artist}/{album}"
client_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
single_folder_playlist:
    enabled: true
    retain_playlist_order: true
    unify_into_album: false
```


# Example Configurations:
```yaml
music_directory: ~/Music
filename_pattern: "{track_number} - {title}"
directory_pattern: "{artist}/{album}"
```
Outputs: `~/Music/Queen/Stone Cold Classics/9 - Bohemian Rhapsody.mp3`
<br><br>
```yaml
music_directory: ~/Music
filename_pattern: "{artist} - {title}"
directory_pattern: ""
```
Outputs: `~/Music/Queen - Bohemian Rhapsody.mp3`
<br><br>
```yaml
music_directory: ~/Music
filename_pattern: "{track_number} of {total_tracks} - {title}"
directory_pattern: "{year}/{artist}/{album}"
```
Outputs: `~/Music/2006/Queen/Stone Cold Classics/9 of 14 - Bohemian Rhapsody.mp3`
<br><br>
```yaml
music_directory: ~/Music
filename_pattern: "{track_number}. {title}"
directory_pattern: "irs/{artist} - {album}"
```
Outputs: `~/Music/irs/Queen - Stone Cold Classics/9. Bohemian Rhapsody.mp3`
<br>

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>